### PR TITLE
Update Snackbar to utilize binding.root

### DIFF
--- a/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
+++ b/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
@@ -71,7 +71,7 @@ class SleepTrackerFragment : Fragment() {
         sleepTrackerViewModel.showSnackBarEvent.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 Snackbar.make(
-                        requireActivity().findViewById(android.R.id.content),
+                        binding.root,
                         getString(R.string.cleared_message),
                         Snackbar.LENGTH_SHORT // How long to display the message.
                 ).show()


### PR DESCRIPTION
Had an issue using the previous line with the snackbar

`requireActivity().findViewById(android.R.id.content)`

according to the Udacity forums, should be using: `binding.root`